### PR TITLE
Add constants module with CRC helper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,10 @@ classifiers = [
 license-files = []
 # Fix from https://github.com/astral-sh/uv/issues/9513#issuecomment-2519527822
 
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
 [tool.semantic_release]
 branch = "main"
 version_toml = ["pyproject.toml:project.version"]

--- a/sok_ble/const.py
+++ b/sok_ble/const.py
@@ -1,0 +1,33 @@
+"""Constants and helpers for interacting with SOK BLE batteries."""
+
+from __future__ import annotations
+
+UUID_RX = "0000ffe1-0000-1000-8000-00805f9b34fb"
+UUID_TX = "0000ffe2-0000-1000-8000-00805f9b34fb"
+
+# Command byte templates extracted from the reference addon
+CMD_NAME = [0xEE, 0xC0, 0x00, 0x00, 0x00]
+CMD_INFO = [0xEE, 0xC1, 0x00, 0x00, 0x00]
+CMD_DETAIL = [0xEE, 0xC2, 0x00, 0x00, 0x00]
+CMD_SETTING = [0xEE, 0xC3, 0x00, 0x00, 0x00]
+CMD_PROTECTION = [0xEE, 0xC4, 0x00, 0x00, 0x00]
+CMD_BREAK = [0xDD, 0xC0, 0x00, 0x00, 0x00]
+
+
+def minicrc(data: list[int] | bytes) -> int:
+    """Compute CRC-8 used by the SOK protocol."""
+
+    crc = 0
+    for byte in data:
+        crc ^= byte & 0xFF
+        for _ in range(8):
+            crc = (crc >> 1) ^ 0x8C if (crc & 1) else crc >> 1
+    return crc
+
+
+def _sok_command(cmd: int) -> bytes:
+    """Return a command frame with CRC for the given command byte."""
+
+    data = [0xEE, cmd, 0x00, 0x00, 0x00]
+    crc = minicrc(data)
+    return bytes(data + [crc])

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,0 +1,13 @@
+from sok_ble.const import minicrc, _sok_command
+
+
+def test_minicrc_known_value():
+    data = [0xEE, 0xC1, 0x00, 0x00, 0x00]
+    assert minicrc(data) == 0xCE
+
+
+def test_sok_command_crc_and_length():
+    cmd = _sok_command(0xC1)
+    assert len(cmd) == 6
+    # CRC byte should match minicrc of base command frame
+    assert cmd[-1] == minicrc([0xEE, 0xC1, 0x00, 0x00, 0x00])

--- a/todo.md
+++ b/todo.md
@@ -32,15 +32,15 @@
 ---
 
 ## ⬜ M2 Constants & CRC Utilities
-- [ ] **Create `sok_ble/const.py`**
-  - [ ] Add `UUID_RX`, `UUID_TX`
-  - [ ] Define command byte lists (`CMD_NAME`, `CMD_INFO`, `CMD_DETAIL`, `CMD_SETTING`, `CMD_PROTECTION`, `CMD_BREAK`)
-  - [ ] Implement `minicrc(data)` crc-8 function
-  - [ ] Implement `_sok_command(cmd: int) -> bytes`
-- [ ] **Add tests** `tests/test_const.py`
-  - [ ] Validate `minicrc` result for sample data
-  - [ ] Validate `_sok_command` length & crc byte
-- [ ] **All tests green**
+- [x] **Create `sok_ble/const.py`**
+  - [x] Add `UUID_RX`, `UUID_TX`
+  - [x] Define command byte lists (`CMD_NAME`, `CMD_INFO`, `CMD_DETAIL`, `CMD_SETTING`, `CMD_PROTECTION`, `CMD_BREAK`)
+  - [x] Implement `minicrc(data)` crc-8 function
+  - [x] Implement `_sok_command(cmd: int) -> bytes`
+- [x] **Add tests** `tests/test_const.py`
+  - [x] Validate `minicrc` result for sample data
+  - [x] Validate `_sok_command` length & crc byte
+- [x] **All tests green**
 
 ---
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,75 @@
+version = 1
+revision = 2
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload_time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload_time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload_time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload_time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload_time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload_time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload_time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload_time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload_time = "2025-01-06T17:26:30.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload_time = "2025-01-06T17:26:25.553Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/aa/405082ce2749be5398045152251ac69c0f3578c7077efc53431303af97ce/pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6", size = 1515232, upload_time = "2025-06-02T17:36:30.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e", size = 363797, upload_time = "2025-06-02T17:36:27.859Z" },
+]
+
+[[package]]
+name = "sok-ble"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pytest", specifier = ">=7.0.1" }]


### PR DESCRIPTION
## Summary
- implement `const.py` containing UUIDs, command bytes, CRC helper and command builder
- create tests verifying the CRC computation and command formatting
- update TODO for completed tasks

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842585d986c832ea59400386e4ef71b