### PR TITLE
Implement SokParser info parsing

### DIFF
--- a/sok_ble/sok_parser.py
+++ b/sok_ble/sok_parser.py
@@ -1,0 +1,63 @@
+"""Parsing utilities for SOK BLE responses."""
+
+from __future__ import annotations
+
+import struct
+from typing import Sequence, Dict
+
+from sok_ble.exceptions import InvalidResponseError
+
+
+# Endian helper functions copied from the reference addon
+
+def get_le_short(data: Sequence[int] | bytes | bytearray, offset: int) -> int:
+    """Read a little-endian signed short."""
+    return struct.unpack_from('<h', bytes(data), offset)[0]
+
+
+def get_le_ushort(data: Sequence[int] | bytes | bytearray, offset: int) -> int:
+    """Read a little-endian unsigned short."""
+    return struct.unpack_from('<H', bytes(data), offset)[0]
+
+
+def get_le_int3(data: Sequence[int] | bytes | bytearray, offset: int) -> int:
+    """Read a 3-byte little-endian signed integer."""
+    b0, b1, b2 = bytes(data)[offset:offset + 3]
+    val = b0 | (b1 << 8) | (b2 << 16)
+    if val & 0x800000:
+        val -= 0x1000000
+    return val
+
+
+def get_be_uint3(data: Sequence[int] | bytes | bytearray, offset: int) -> int:
+    """Read a 3-byte big-endian unsigned integer."""
+    b0, b1, b2 = bytes(data)[offset:offset + 3]
+    return (b0 << 16) | (b1 << 8) | b2
+
+
+class SokParser:
+    """Parse buffers returned from SOK batteries."""
+
+    @staticmethod
+    def parse_info(buf: bytes) -> Dict[str, float | int]:
+        """Parse the information frame for voltage, current and SOC."""
+        if len(buf) < 18:
+            raise InvalidResponseError("Info buffer too short")
+
+        cells = [
+            get_le_ushort(buf, 0),
+            get_le_ushort(buf, 2),
+            get_le_ushort(buf, 4),
+            get_le_ushort(buf, 6),
+        ]
+        voltage = (sum(cells) / len(cells) * 4) / 1000
+
+        current = get_le_int3(buf, 8) / 10
+
+        soc = struct.unpack_from('<H', buf, 16)[0]
+
+        return {
+            "voltage": voltage,
+            "current": current,
+            "soc": soc,
+        }

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on path for test imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_parser_info.py
+++ b/tests/test_parser_info.py
@@ -1,0 +1,24 @@
+from sok_ble.sok_parser import SokParser
+
+
+def test_parse_info_basic():
+    hex_data = bytes.fromhex(
+        "E4 0C E9 0C EE 0C F3 0C 64 00 00 00 00 00 00 00 41 00"
+    )
+    result = SokParser.parse_info(hex_data)
+    assert result == {
+        "voltage": 13.23,
+        "current": 10.0,
+        "soc": 65,
+    }
+
+
+def test_parse_info_invalid_length():
+    data = b"\x00" * 10
+    try:
+        SokParser.parse_info(data)
+        assert False, "Expected InvalidResponseError"
+    except Exception as err:
+        from sok_ble.exceptions import InvalidResponseError
+
+        assert isinstance(err, InvalidResponseError)

--- a/todo.md
+++ b/todo.md
@@ -56,13 +56,13 @@
 ---
 
 ## ⬜ M4 SokParser (Minimal)
-- [ ] **Create `sok_ble/sok_parser.py`**
-  - [ ] Copy endian helper functions (`get_le_short`, `get_le_ushort`, `get_le_int3`, `get_be_uint3`)
-  - [ ] Implement `class SokParser` ➜ `parse_info(buf)` → returns `voltage`, `current`, `soc`
-  - [ ] Raise `InvalidResponseError` on malformed buf
-- [ ] **Add tests** `tests/test_parser_info.py`
-  - [ ] Fixture hex → dict comparison
-- [ ] **All tests green**
+- [x] **Create `sok_ble/sok_parser.py`**
+  - [x] Copy endian helper functions (`get_le_short`, `get_le_ushort`, `get_le_int3`, `get_be_uint3`)
+  - [x] Implement `class SokParser` ➜ `parse_info(buf)` → returns `voltage`, `current`, `soc`
+  - [x] Raise `InvalidResponseError` on malformed buf
+- [x] **Add tests** `tests/test_parser_info.py`
+  - [x] Fixture hex → dict comparison
+- [x] **All tests green**
 
 ---
 


### PR DESCRIPTION
## Summary
- add endian helper functions and `SokParser.parse_info`
- provide parser tests with example payload
- allow tests to locate project package
- check off SokParser TODO items

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ffd64330832e848e74d82fb13d8b