### PR TITLE
fix: allow older bleak-retry-connector version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "bleak>=0.22.3",
-    "bleak-retry-connector>=3.10.0",
+    "bleak-retry-connector>=3.9.0",
 ]
 authors = [
     {name = "Mitchell Carlson", email = "mitchell.carlson.pro@gmail.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -258,7 +258,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bleak", specifier = ">=0.22.3" },
-    { name = "bleak-retry-connector", specifier = ">=3.10.0" },
+    { name = "bleak-retry-connector", specifier = ">=3.9.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
- allow older bleak-retry-connector version