### PR TITLE
Use Bleak services property

### DIFF
--- a/src/sok_ble/sok_bluetooth_device.py
+++ b/src/sok_ble/sok_bluetooth_device.py
@@ -70,7 +70,7 @@ class SokBluetoothDevice:
 
                 # Force service discovery
                 async with async_timeout.timeout(5):
-                    await client.get_services()
+                    _ = client.services
                 await asyncio.sleep(0.15)
 
                 try:

--- a/tests/test_device_full.py
+++ b/tests/test_device_full.py
@@ -20,7 +20,8 @@ class DummyClient:
     async def read_gatt_char(self, *args, **kwargs):
         return self._responses.pop(0)
 
-    async def get_services(self):
+    @property
+    def services(self):
         return []
 
 

--- a/tests/test_device_minimal.py
+++ b/tests/test_device_minimal.py
@@ -26,7 +26,8 @@ class DummyClient:
     async def read_gatt_char(self, *args, **kwargs):
         return self._responses.pop(0)
 
-    async def get_services(self):
+    @property
+    def services(self):
         return []
 
 


### PR DESCRIPTION
## Summary
- use the `services` property instead of `get_services`
- adapt DummyClient in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847b2f31494832eb11f0431b3c00f25